### PR TITLE
Makefile: init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 DAPP_DIR = $(CURDIR)/uniswap-v2-core
+DAPP_SRC = contracts
+
+SOLC_VERSION = 0.5.15
+# optionally enable the optimizer:
+# SOLC_FLAGS = "--optimize --optimize-runs 1000000"
+SOLC_FLAGS =
 
 dapp:
 	dapp --version
-	cd $(DAPP_DIR) && DAPP_SRC=contracts dapp --use solc:0.5.15 build && cd -
+	cd $(DAPP_DIR) && DAPP_SRC=$(DAPP_SRC) DAPP_SOLC_VERSION=$(SOLC_VERSION) SOLC_FLAGS=$(SOLC_FLAGS) dapp build && cd -


### PR DESCRIPTION
For now, uses dapp as a build system.

This is to make it easy to build the project in Buildbot, since it already has facilities for running Makefiles.