### PR TITLE
makefile: clone submodules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
-DAPP_DIR = $(CURDIR)/uniswap-v2-core
-DAPP_SRC = contracts
+DAPP_DIR=$(CURDIR)/uniswap-v2-core
+DAPP_SRC=contracts
 
-SOLC_VERSION = 0.5.15
+SOLC_VERSION=0.5.15
 # optionally enable the optimizer:
 # SOLC_FLAGS = "--optimize --optimize-runs 1000000"
-SOLC_FLAGS =
+SOLC_FLAGS=
 
 dapp:
 	dapp --version
+	git submodule update --init --recursive
 	cd $(DAPP_DIR) && DAPP_SRC=$(DAPP_SRC) DAPP_SOLC_VERSION=$(SOLC_VERSION) SOLC_FLAGS=$(SOLC_FLAGS) dapp build && cd -


### PR DESCRIPTION
And standardize on no spaces around `=`: since it works both with and
without in Makefiles, but not in Bash, let's just settle on Bash syntax.