### PR TITLE
ERC20: burn -> forfeit

### DIFF
--- a/src/uniswap.act.md
+++ b/src/uniswap.act.md
@@ -298,8 +298,8 @@ returns 1
 ### Burn
 
 ```act
-behaviour burn of UniswapV2
-interface burn(uint value)
+behaviour forfeit of UniswapV2
+interface forfeit(uint value)
 
 for all
 
@@ -407,8 +407,8 @@ returns 1
 ### BurnFrom
 
 ```act
-behaviour burnFrom of UniswapV2
-interface burnFrom(address from, uint value)
+behaviour forfeitFrom of UniswapV2
+interface forfeitFrom(address from, uint value)
 
 for all
 


### PR DESCRIPTION
These fail locally with the following output and I don't know why:

```
Using evm-semantics from /home/me/code/dapphub/klab/evm-semantics
Proof STARTING: c2dacf94ec45a8672732ed0f0546ef64deb7864182dc27c6ce171ea5c93e8732.k [ERC20_forfeitFrom_pass_rough] (with state logging)
[Error] Critical: Z3 crashed on input query:
(declare-sort WordStack)
(declare-fun asByteStack (Int WordStack) WordStack)
(declare-fun asWord (WordStack) Int)
(declare-fun buf (Int Int) WordStack)
(declare-fun sizeWordStack (WordStack) Int)
(declare-fun _dotWS () WordStack)
(declare-fun _plusWS_ (WordStack WordStack) WordStack)
(declare-fun _WS_ (Int WordStack) WordStack)
(declare-fun chop (Int) Int)
(declare-fun smt_keccak (WordStack) Int)
(declare-fun smt_nthbyteof (Int Int Int) Int)
(declare-fun sizeWordStackAux (WordStack Int) Int)
(assert (forall ((|R_I_276| Int)) (= (chop |R_I_276|) (mod |R_I_276| 115792089237316195423570985008687907853269984665640564039457584007913129639936))))
(assert (forall ((|R__0_314| WordStack)(|R__1_315| Int)) (= (>= (sizeWordStackAux |R__0_314| |R__1_315|) 0) true)))
(declare-fun |W| () Int)
(assert (and
  true
  (not (and
	(= (= |W| 0) false)))
))
result:
(error "line 96 column 70: invalid using-params combinator, unknown parameter timeout")

while proving implication LHS:
ConjunctiveFormula(
)
RHS:
ConjunctiveFormula(
  equalities:
    _==K_(_==K_(W:Int,, Int(#"0")),, Bool(#"false"))
)
  while evaluating function bool2Word
Proof 113 REJECT: c2dacf94ec45a8672732ed0f0546ef64deb7864182dc27c6ce171ea5c93e8732.k [ERC20_forfeitFrom_pass_rough] (with state logging)
```