### PR TITLE
types -> for all

### DIFF
--- a/src/uniswap.act.md
+++ b/src/uniswap.act.md
@@ -8,7 +8,7 @@ UniswapV2 liquidity token behaviour.
 behaviour totalSupply of ERC20
 interface totalSupply()
 
-types
+for all
 
     Supply : uint256
 
@@ -27,7 +27,7 @@ returns Supply
 behaviour balanceOf of ERC20
 interface balanceOf(address who)
 
-types
+for all
 
     BalanceOf : uint256
 
@@ -46,7 +46,7 @@ returns BalanceOf
 behaviour allowance of ERC20
 interface allowance(address holder, address spender)
 
-types
+for all
 
     Allowed : uint256
 
@@ -65,7 +65,7 @@ returns Allowed
 behaviour DOMAIN_SEPARATOR of ERC20
 interface DOMAIN_SEPARATOR()
 
-types
+for all
 
     Dom : uint256
 
@@ -96,7 +96,7 @@ returns keccak(#parseByteStackRaw("Permit(address owner,address spender,uint256 
 behaviour nonces of ERC20
 interface nonces(address who)
 
-types
+for all
 
     Nonce : uint256
 
@@ -119,7 +119,7 @@ returns Nonce
 behaviour transfer-diff of ERC20
 interface transfer(address to, uint value)
 
-types
+for all
 
     SrcBal : uint256
     DstBal : uint256
@@ -148,7 +148,7 @@ returns 1
 behaviour transfer-same of ERC20
 interface transfer(address to, uint value)
 
-types
+for all
 
     SrcBal : uint256
 
@@ -176,7 +176,7 @@ returns 1
 behaviour burn of ERC20
 interface burn(uint value)
 
-types
+for all
 
     SrcBal : uint256
     Supply : uint256
@@ -203,7 +203,7 @@ iff in range uint256
 behaviour approve of ERC20
 interface approve(address spender, uint value)
 
-types
+for all
 
     Allowance : uint256
 
@@ -224,7 +224,7 @@ returns 1
 behaviour transferFrom-diff of ERC20
 interface transferFrom(address from, address to, uint value)
 
-types
+for all
 
     SrcBal  : uint256
     DstBal  : uint256
@@ -255,7 +255,7 @@ returns 1
 behaviour transferFrom-same of ERC20
 interface transferFrom(address from, address to, uint value)
 
-types
+for all
 
     FromBal : uint256
     Allowed : uint256
@@ -285,7 +285,7 @@ returns 1
 behaviour burnFrom of ERC20
 interface burnFrom(address from, uint value)
 
-types
+for all
 
     FromBal : uint256
     Allowed : uint256
@@ -334,7 +334,7 @@ function permit(
 behaviour permit of ERC20
 interface permit(address owner, address spender, uint value, uint nonce, uint deadline, uint8 v, bytes32 r, bytes32 s)
 
-types
+for all
 
     Nonce   : uint256
     Allowed : uint256


### PR DESCRIPTION
As discussed, `types` is misleading because what follows is not a
variable declaration, but rather the declaration of a set of constraints
on K `Int`s.

Let the bikshedding begin!