### PR TITLE
Erc20 helpers

### DIFF
--- a/src/uniswap.act.md
+++ b/src/uniswap.act.md
@@ -466,3 +466,24 @@ if
 
     #rangeUInt(256, Nonce + 1)
 ```
+
+## ERC20 Lemmas
+
+### Add
+
+```act
+behaviour add of UniswapV2
+interface add(uint x, uint y) internal
+
+stack
+
+    y : x : JMPTO : WS => JMPTO : x + y : WS
+
+iff in range uint256
+
+    x + y
+
+if
+
+    #sizeWordStack(WS) <= 100
+```


### PR DESCRIPTION
This is currently failing because klab's static analyzer can't find the PC for internal functions in libraries.

We are going to wait with FVing these internal functions until we know for sure that they want to keep using libraries.