### PR TITLE
UniswapV2Factory: mutators

### DIFF
--- a/src/lemmas.k.md
+++ b/src/lemmas.k.md
@@ -11,6 +11,7 @@ rule A -Word B <=Int A => #rangeUInt(256, A -Int B)
   requires #rangeUInt(256, A) andBool #rangeUInt(256, B)
 ```
 
+
 ### Numerical Constants
 
 The `evm-semantics` only defines ranges and constants for a few solidity types. A couple of extra
@@ -42,6 +43,18 @@ rule #rangeUInt(112, X) => #range(0 <= X <= maxUInt112) [macro]
 ```k
 syntax Int ::= "pow224"                                                             [function]
 rule pow224 => 26959946667150639794667015087019630673637144422540572481103610249216 [macro]
+```
+
+### Solidity masking
+
+When writing to storage, Solidity performs complement masking on existing values.
+
+```k
+syntax Int ::= "notMaxUInt160"   [function]
+rule notMaxUInt160 => 115792089237316195423570985007226406215939081747436879206741300988257197096960 [macro]
+
+rule (notMaxUInt160 &Int A) => 0
+  requires #rangeAddress(A)
 ```
 
 ### Packed Storage { `uint112` `uint112` `uint32` }

--- a/src/uniswap.act.md
+++ b/src/uniswap.act.md
@@ -117,6 +117,52 @@ if
 returns Exchange
 ```
 
+## Mutators
+
+### updating the fee setter
+
+The current fee setter can appoint a new fee setter
+
+```act
+behaviour setFeeToSetter of UniswapV2Factory
+interface setFeeToSetter(address usr)
+
+for all
+
+    Setter : address
+
+storage
+
+    feeToSetter |-> Setter => usr
+
+iff
+    VCallValue == 0
+    CALLER_ID == Setter
+```
+
+### updating the fee recipient
+
+The current fee setter can appoint a new fee recipient
+
+ ```act
+behaviour setFeeTo of UniswapV2Factory
+interface setFeeTo(address usr)
+
+for all
+
+    FeeTo  : address
+    Setter : address
+
+storage
+
+    feeToSetter |-> Setter
+    feeTo       |-> FeeTo => usr
+
+iff
+    VCallValue == 0
+    CALLER_ID == Setter
+```
+
 UniswapV2Exchange
 =================
 


### PR DESCRIPTION
Specs are passing.

But not sure about the correctness of this:

Before performing `SSTORE` solidity runs an `AND` on the existing slot value with the number type's `complement`. For these address types this looks like:

```
(NOT maxUInt160) AND existingSlotValue => 0
```

This result is then `OR`'d with the new value before saving the result. So in order for these specs to pass I've added this rule:

```
rule (X |Int (notMaxUInt160 &Int Y)) => X
  requires #rangeUInt(256, X)
  andBool #rangeUInt(256, Y)
```

1. Is this some new solidity beauracracy or is there a more general lemma that has been used previously to handle this?

2. ~Why doesn't this rule work with requires `#rangeUInt(160, _)`, even though both `X` and `Y` have address constraints applied?~

3. Can we assume that `AND`ing with the complement will always rewrite to 0? 