### PR TITLE
UniswapV2Factory: createPair

### DIFF
--- a/config.json
+++ b/config.json
@@ -39,7 +39,13 @@
     "UniswapV2Pair_mint-feeMinted-diff_pass": "1d",
     "UniswapV2Pair_mint-feeMinted-same_pass_rough": "1d",
     "UniswapV2Pair_mint-feeMinted-same_fail_rough": "1d",
-    "UniswapV2Pair_mint-feeMinted-same_pass": "1d"
+    "UniswapV2Pair_mint-feeMinted-same_pass": "1d",
+    "UniswapV2Factory_createPair-lt_pass_rough": "72h",
+    "UniswapV2Factory_createPair-lt_fail_rough": "72h",
+    "UniswapV2Factory_createPair-lt_pass": "72h",
+    "UniswapV2Factory_createPair-gt_pass_rough": "72h",
+    "UniswapV2Factory_createPair-gt_fail_rough": "72h",
+    "UniswapV2Factory_createPair-gt_pass": "72h"
   },
   "memory" : {
     "UniswapV2Pair_mint-noFee-first-diff_pass_rough": "30G",
@@ -59,7 +65,13 @@
     "UniswapV2Pair_mint-feeMinted-diff_pass": "30G",
     "UniswapV2Pair_mint-feeMinted-same_pass_rough": "30G",
     "UniswapV2Pair_mint-feeMinted-same_fail_rough": "30G",
-    "UniswapV2Pair_mint-feeMinted-same_pass": "30G"
+    "UniswapV2Pair_mint-feeMinted-same_pass": "30G",
+    "UniswapV2Factory_createPair-lt_pass_rough": "25G",
+    "UniswapV2Factory_createPair-lt_fail_rough": "25G",
+    "UniswapV2Factory_createPair-lt_pass": "25G",
+    "UniswapV2Factory_createPair-gt_pass_rough": "25G",
+    "UniswapV2Factory_createPair-gt_fail_rough": "25G",
+    "UniswapV2Factory_createPair-gt_pass": "25G"
   },
   "dapp_root": "./uniswap-v2-core",
   "solc_output_path": "build/Combined-Json.json"

--- a/src/storage.k.md
+++ b/src/storage.k.md
@@ -6,6 +6,9 @@ Defining shortnames for constants here allows us to keep act specification a
 little less verbose.
 
 ```k
+syntax Int ::= "Constants.EIP712Domain" [function]
+rule Constants.EIP712Domain => keccak(#parseByteStackRaw("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")) [macro]
+
 syntax Int ::= "Constants.PermitTypehash" [function]
 rule Constants.PermitTypehash => keccak(#parseByteStackRaw("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)")) [macro]
 ```
@@ -172,9 +175,6 @@ slot 3, the number represented to here by `pair0`. Subsequent addresses are
 stored at a `uint256` offset from this key.
 
 ```k
-syntax Int ::= "pair0" [function]
-rule pair0 => 87903029871075914254377627908054574944891091886930582284385770809450030037083 [macro]
-
 syntax Int ::= "#UniswapV2Factory.allPairs" "[" Int "]" [function]
 rule #UniswapV2Factory.allPairs[N] => pair0 +Int N
 ```


### PR DESCRIPTION
Requires klab support for runtime contract creation.