### PR TITLE
Factory: allExchanges: document overflow

### DIFF
--- a/src/storage.k.md
+++ b/src/storage.k.md
@@ -166,20 +166,3 @@ rule exchanges0 => 8790302987107591425437762790805457494489109188693058228438577
 syntax Int ::= "#UniswapV2Factory.allExchanges" "[" Int "]" [function]
 rule #UniswapV2Factory.allExchanges[N] => exchanges0 +Int N
 ```
-
-The largest index that can be represented at slot 3 before integer overflow is
-`maxUInt256 - exchanges0`.  The maximum number of addresses that can be stored
-by the `allExchanges` array is therefore `maxUInt256 - exchanges0 + 1`.
-
-Max. exchanges: 27889059366240281169193357100633332908378892778709981755071813198463099602853
-
-`K` applies a chop rule when getting the position offset but Solidity doesn't
-do any overflow checking on the index because it is already constrained by the
-length of the array. Hence we skip this constraint here.
-
-TODO: ensure overflow protection when pushing items to the array in
-`createExchange`.
-
-```k
-rule chop(exchanges0 +Int N) => exchanges0 +Int N
-```

--- a/src/uniswap.act.md
+++ b/src/uniswap.act.md
@@ -26,6 +26,17 @@ returns To
 
 ### allExchanges
 
+`allExchanges` is an array holding the address of every exchange created using the `Factory`.
+
+`exchanges0` is the index in storage of the first array element. Subsequent array elements are read
+from `exchanges0 + index`. The maximum number of addresses that can be stored by the `allExchanges`
+array before overflow is therefore `maxUInt256 - exchanges0 + 1 ==
+27889059366240281169193357100633332908378892778709981755071813198463099602853`.
+
+We do not currently specify the behaviour of the array after overflow has occured.
+
+TODO: ensure that `createExchange` checks for overflow on the `allExchanges` array.
+
 ```act
 behaviour allExchanges of UniswapV2Factory
 interface allExchanges(uint256 index)
@@ -44,6 +55,11 @@ iff
 
     Length > index
     VCallValue == 0
+
+if
+
+    // ignore array overflow
+    Length <= maxUInt256 - exchanges0 + 1
 
 returns Exchange
 ```


### PR DESCRIPTION
- rm untrue lemma and replace with an `if` block in the spec
- document overflow conditions in the main spec file

I prefer to be explicit here and encode the overflow using an `if` in the main spec.