### PR TITLE
direnv: use lorri if available

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,7 @@
-use nix
+# vim: set ft=sh:
+
+if has lorri; then
+    eval "$(lorri direnv)"
+else
+    use nix
+fi

--- a/shell.nix
+++ b/shell.nix
@@ -12,7 +12,7 @@ let
   dapptools = import dappSrc {};
 
 in
-  pkgs.stdenv.mkDerivation {
+  pkgs.mkShell {
     name = "k-uniswap";
     buildInputs = klab.buildInputs ++ [
       dapptools.dapp
@@ -22,7 +22,7 @@ in
       export NIX_PATH="nixpkgs=${pkgs.path}"
       export DAPPTOOLS=${dappSrc}
 
-      export KLAB_PATH=$(pwd)/deps/klab
+      export KLAB_PATH=${toString ./deps/klab}
       export PATH=$KLAB_PATH/node_modules/.bin/:$KLAB_PATH/bin:$PATH
       export KLAB_EVMS_PATH=$KLAB_PATH/evm-semantics
     '';


### PR DESCRIPTION
[`lorri`](https://github.com/target/lorri) is a `nix-shell` replacement that:

1. caches shells (no more multi second delay when entering the shell)
2. adds a gcroot for each shell (no more waiting for nix to redownload the world after a gc run)

This commit adds support for `lorri` in the `envrc` and prefers it if available.